### PR TITLE
Fix Install

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,3 +15,4 @@ test:
     - flake8 md_pdf/ --ignore=E128,E501
     - safety check
     - bandit -r md_pdf/
+    - mdp --help

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 setup(
@@ -13,6 +13,7 @@ setup(
         "pyscss==1.3.5",
         "PyYAML==3.12"
     ],
+    packages=find_packages(),
     entry_points="""
         [console_scripts]
         mdp=md_pdf.cli:cli

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         "PyYAML==3.12"
     ],
     packages=find_packages(),
+    include_package_data=True,
     entry_points="""
         [console_scripts]
         mdp=md_pdf.cli:cli


### PR DESCRIPTION
Currently installing with pip directly from GitHub downloads all dependencies, but doesn't actually make the `md_pdf` package accessible, making the executable error.