### PR TITLE
Dont render assets to project dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,10 +245,3 @@ ENV/
 # End of https://www.gitignore.io/api/node,linux,python,jetbrains,archlinuxpackages
 
 out/
-md_pdf/assets/templates/cover.html
-md_pdf/assets/templates/header.html
-md_pdf/assets/templates/footer.html
-md_pdf/assets/templates/toc.xsl
-md_pdf/assets/static/style.css
-md_pdf/assets/csl/
-md_pdf/assets/styles-master/

--- a/md_pdf/assets/templates/cover-template.html
+++ b/md_pdf/assets/templates/cover-template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" href="../static/style.css" />
+    <link rel="stylesheet" href="{{ static_dir }}/style.css" />
   </head>
   <body class="cover">
     <h1>{{ title }}</h1>

--- a/md_pdf/assets/templates/footer-template.html
+++ b/md_pdf/assets/templates/footer-template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" href="../static/style.css" />
+    <link rel="stylesheet" href="{{ static_dir }}/style.css" />
   </head>
   <body class="footer">
     <table>
@@ -17,6 +17,6 @@
         </td>
       </tr>
     </table>
-    <script type="text/javascript" src="../static/context.js"></script>
+    <script type="text/javascript" src="{{ internal_static_dir }}/context.js"></script>
   </body>
 </html>

--- a/md_pdf/assets/templates/header-template.html
+++ b/md_pdf/assets/templates/header-template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" href="../static/style.css" />
+    <link rel="stylesheet" href="{{ static_dir }}/style.css" />
   </head>
   <body class="header">
     <table>
@@ -15,6 +15,6 @@
         </td>
       </tr>
     </table>
-    <script type="text/javascript" src="../static/context.js"></script>
+    <script type="text/javascript" src="{{ internal_static_dir }}/context.js"></script>
   </body>
 </html>

--- a/md_pdf/build/context.py
+++ b/md_pdf/build/context.py
@@ -1,4 +1,4 @@
-from md_pdf.consts import TEMPLATES_DIR, STATIC_DIR, DATE_FORMAT, TIME_FORMAT, DATETIME_FORMAT
+from md_pdf.consts import TEMPLATES_DIR, STATIC_DIR, DATE_FORMAT, TIME_FORMAT, DATETIME_FORMAT, INTERNAL_TEMPLATES_DIR, INTERNAL_STATIC_DIR
 from word_count import word_count
 from md_pdf.utils import get_plain_text
 from md_pdf import __version__
@@ -10,6 +10,8 @@ import os
 EXTRA_CONTEXT = {
     'templates_dir': TEMPLATES_DIR,
     'static_dir': STATIC_DIR,
+    'internal_templates_dir': INTERNAL_TEMPLATES_DIR,
+    'internal_static_dir': INTERNAL_STATIC_DIR,
     'date': datetime.datetime.now().strftime(DATE_FORMAT),
     'time': datetime.datetime.now().strftime(TIME_FORMAT),
     'datetime': datetime.datetime.now().strftime(DATETIME_FORMAT),

--- a/md_pdf/build/css.py
+++ b/md_pdf/build/css.py
@@ -1,10 +1,10 @@
 from scss import Compiler
-from md_pdf.consts import STATIC_DIR
+from md_pdf.consts import INTERNAL_STATIC_DIR
 from md_pdf.build.pdf import STYLE_FILE
 import os
 
 
-STYLE_SRC_FILE = os.path.join(STATIC_DIR, 'style.scss')
+STYLE_SRC_FILE = os.path.join(INTERNAL_STATIC_DIR, 'style.scss')
 
 
 def render_css():

--- a/md_pdf/build/templates.py
+++ b/md_pdf/build/templates.py
@@ -1,5 +1,5 @@
 from jinja2 import Template
-from md_pdf.consts import TEMPLATES_DIR
+from md_pdf.consts import TEMPLATES_DIR, INTERNAL_TEMPLATES_DIR
 from md_pdf.build.context import get_context
 import os
 import logging
@@ -8,7 +8,7 @@ logger = logging.getLogger(__file__)
 
 
 FILE_NAME_FORMAT = os.path.join(TEMPLATES_DIR, "{}.html")
-TEMPLATE_FORMAT = os.path.join(TEMPLATES_DIR, "{}-template.html")
+TEMPLATE_FORMAT = os.path.join(INTERNAL_TEMPLATES_DIR, "{}-template.html")
 
 
 def render_page(input_file, output_file, context):
@@ -30,4 +30,4 @@ def render_templates(config, content):
     ]:
         render_page(TEMPLATE_FORMAT.format(template), FILE_NAME_FORMAT.format(template), context)
     if config.get('toc', False):
-        render_page(os.path.join(TEMPLATES_DIR, 'toc-template.xsl'), os.path.join(TEMPLATES_DIR, 'toc.xsl'), context)
+        render_page(os.path.join(INTERNAL_TEMPLATES_DIR, 'toc-template.xsl'), os.path.join(TEMPLATES_DIR, 'toc.xsl'), context)

--- a/md_pdf/consts.py
+++ b/md_pdf/consts.py
@@ -1,12 +1,23 @@
 import os
+import shutil
 
 PROJECT_DIR = os.path.dirname(__file__)
 WORKING_DIR = os.getcwd()
-ASSET_DIR = os.path.join(PROJECT_DIR, 'assets')
 
-CSL_DIR = os.path.join(ASSET_DIR, 'csl')
-TEMPLATES_DIR = os.path.join(ASSET_DIR, 'templates')
-STATIC_DIR = os.path.join(ASSET_DIR, 'static')
+try:
+    ASSETS_DIR = os.path.join(os.environ['APPDATA'], '.mdp')
+except KeyError:
+    ASSETS_DIR = os.path.join(os.environ['HOME'], '.mdp')
+
+
+CSL_DIR = os.path.join(ASSETS_DIR, 'csl')
+TEMPLATES_DIR = os.path.join(ASSETS_DIR, 'templates')
+STATIC_DIR = os.path.join(ASSETS_DIR, 'static')
+
+INTERNAL_ASSETS_DIR = os.path.join(PROJECT_DIR, 'assets')
+INTERNAL_STATIC_DIR = os.path.join(INTERNAL_ASSETS_DIR, 'static')
+INTERNAL_TEMPLATES_DIR = os.path.join(INTERNAL_ASSETS_DIR, 'templates')
+
 
 CONFIG_FILE = os.path.join(WORKING_DIR, 'mdp.yml')
 
@@ -15,3 +26,8 @@ CSL_DOWNLOAD_LINK = "https://github.com/citation-style-language/styles/archive/m
 DATE_FORMAT = "%d %B %Y"
 TIME_FORMAT = "%H:%M"
 DATETIME_FORMAT = "{} {}".format(DATE_FORMAT, TIME_FORMAT)
+
+
+os.makedirs(ASSETS_DIR, exist_ok=True)
+os.makedirs(TEMPLATES_DIR, exist_ok=True)
+os.makedirs(STATIC_DIR, exist_ok=True)

--- a/md_pdf/consts.py
+++ b/md_pdf/consts.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 
 PROJECT_DIR = os.path.dirname(__file__)
 WORKING_DIR = os.getcwd()

--- a/md_pdf/csl.py
+++ b/md_pdf/csl.py
@@ -1,4 +1,4 @@
-from md_pdf.consts import CSL_DOWNLOAD_LINK, ASSET_DIR, CSL_DIR
+from md_pdf.consts import CSL_DOWNLOAD_LINK, ASSETS_DIR, CSL_DIR
 from md_pdf.exceptions import PrematureExit
 import os
 import urllib
@@ -12,7 +12,7 @@ import logging
 logger = logging.getLogger(__file__)
 
 
-CSL_TEMP_DIR = os.path.join(ASSET_DIR, 'styles-master')
+CSL_TEMP_DIR = os.path.join(ASSETS_DIR, 'styles-master')
 
 
 def check_csl():

--- a/md_pdf/csl.py
+++ b/md_pdf/csl.py
@@ -43,7 +43,7 @@ def download_csl():
             bar.start(max_value=len(member_list))
 
             for i, member in enumerate(member_list):
-                csl_zip.extract(member, path=ASSET_DIR)
+                csl_zip.extract(member, path=ASSETS_DIR)
                 bar.update(i)
 
             bar.finish()


### PR DESCRIPTION
Dont render templates and assets to the project dir. In normal installs, the install directory may not be writable to the user, so store it in `%APPDATA%/.mdp` for windows users, and `~/.mdp` for everyone else