### PR TITLE
Unified template render

### DIFF
--- a/md_pdf/build/content.py
+++ b/md_pdf/build/content.py
@@ -1,8 +1,8 @@
-from jinja2 import Template
 from bs4 import BeautifulSoup
 import os
 import logging
 from md_pdf.build.context import get_context
+from md_pdf.build.jinja import render_content
 
 logger = logging.getLogger(__file__)
 
@@ -38,9 +38,8 @@ def add_body_class(doc, config):
 
 def render_template(html, config):
     logger.debug("Rendering Template...")
-    template = Template(html)
     context = get_context(config, html)
-    return template.render(context)
+    return render_content(html, context)
 
 
 def parse_template(doc, config):

--- a/md_pdf/build/jinja.py
+++ b/md_pdf/build/jinja.py
@@ -1,0 +1,15 @@
+from jinja2 import Environment
+
+
+def render_content(content, context):
+    env = Environment(
+        trim_blocks=True,
+        lstrip_blocks=True,
+        extensions=[
+            'jinja2.ext.with_',
+            'jinja2.ext.loopcontrols'
+        ]
+
+    )
+    template = env.from_string(content)
+    return template.render(**context)

--- a/md_pdf/build/jinja.py
+++ b/md_pdf/build/jinja.py
@@ -3,6 +3,7 @@ from jinja2 import Environment
 
 def render_content(content, context):
     env = Environment(
+        autoescape=True,
         trim_blocks=True,
         lstrip_blocks=True,
         extensions=[

--- a/md_pdf/build/templates.py
+++ b/md_pdf/build/templates.py
@@ -1,6 +1,6 @@
-from jinja2 import Template
 from md_pdf.consts import TEMPLATES_DIR, INTERNAL_TEMPLATES_DIR
 from md_pdf.build.context import get_context
+from md_pdf.build.jinja import render_content
 import os
 import logging
 
@@ -14,11 +14,10 @@ TEMPLATE_FORMAT = os.path.join(INTERNAL_TEMPLATES_DIR, "{}-template.html")
 def render_page(input_file, output_file, context):
     logger.debug("Rendering {}...".format(os.path.splitext(os.path.basename(output_file))[0].title()))
     with open(input_file) as f:
-        template = Template(f.read())
+        content = render_content(f.read(), context)
     with open(output_file, "w") as f:
-        cover = template.render(context)
-        f.write(cover)
-        return cover
+        f.write(content)
+        return content
 
 
 def render_templates(config, content):


### PR DESCRIPTION
Use a single block of code for rendering templates. This allows for better extension of `jinja`!